### PR TITLE
Updated gemspec and adaption to updated event interface

### DIFF
--- a/lib/logstash/filters/hashid.rb
+++ b/lib/logstash/filters/hashid.rb
@@ -21,9 +21,6 @@ class LogStash::Filters::Hashid < LogStash::Filters::Base
   # Source field(s) to base the hash calculation on
   config :source, :validate => :array, :default => ['message']
 
-  # Timestamp field to use for the timestamp prefix
-  config :timestamp_field, :validate => :string, :default => '@timestamp'
-
   # Target field.
   # Will overwrite current value of a field if it exists.
   config :target, :validate => :string, :default => 'hashid'
@@ -65,7 +62,7 @@ class LogStash::Filters::Hashid < LogStash::Filters::Base
 
     epoch_array = []
     if @add_timestamp_prefix
-      epoch = event.get(@timestamp_field).to_i
+      epoch = event.get('@timestamp').to_i
       epoch_array.push(epoch >> 24)
       epoch_array.push((epoch >> 16) % 256)
       epoch_array.push((epoch >> 8) % 256)

--- a/lib/logstash/filters/hashid.rb
+++ b/lib/logstash/filters/hashid.rb
@@ -54,7 +54,7 @@ class LogStash::Filters::Hashid < LogStash::Filters::Base
     hmac = OpenSSL::HMAC.new(@key, @digest.new)
 
     @source.sort.each do |k|
-      hmac.update("|#{k}|#{event[k]}") 
+      hmac.update("|#{k}|#{event.get(k)}") 
     end
 
     hash = hmac.digest
@@ -65,7 +65,7 @@ class LogStash::Filters::Hashid < LogStash::Filters::Base
 
     epoch_array = []
     if @add_timestamp_prefix
-      epoch = event[@timestamp_field].to_i
+      epoch = event.get(@timestamp_field).to_i
       epoch_array.push(epoch >> 24)
       epoch_array.push((epoch >> 16) % 256)
       epoch_array.push((epoch >> 8) % 256)
@@ -74,7 +74,7 @@ class LogStash::Filters::Hashid < LogStash::Filters::Base
 
     binary_array = epoch_array + hash.unpack('C*')
 
-    event[@target] = encode_to_sortable_string(binary_array).force_encoding(Encoding::UTF_8)
+    event.set(@target, encode_to_sortable_string(binary_array).force_encoding(Encoding::UTF_8))
   end
 
   def select_digest(method)

--- a/logstash-filter-hashid.gemspec
+++ b/logstash-filter-hashid.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # Files
-  s.files = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
+  s.files = Dir['lib/**/*','spec/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
 
   # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "filter" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", ">= 2.0.0.beta2", "< 3.0.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_development_dependency 'logstash-devutils'
 end
-

--- a/spec/filters/hashid_spec.rb
+++ b/spec/filters/hashid_spec.rb
@@ -253,23 +253,6 @@ describe LogStash::Filters::Hashid do
       end
     end
 
-    describe '12 byte MD5 with custom timestamp field used for prefix' do
-      config <<-CONFIG
-        filter {
-          hashid {
-            source => ['message']
-            method => 'MD5'
-            timestamp_field => 'ts'
-            add_timestamp_prefix => true
-            hash_bytes_used => 12
-          }
-        }
-      CONFIG
-
-      sample("ts" => epoch_time, "message" => "testmessage") do
-        insist { subject.get("hashid") } == 'KcMScCbSbOQ81JSd3HmPFk'
-      end
-    end
   end
 
 end

--- a/spec/filters/hashid_spec.rb
+++ b/spec/filters/hashid_spec.rb
@@ -16,7 +16,7 @@ describe LogStash::Filters::Hashid do
     CONFIG
 
     sample("message" => "testmessage") do
-      insist { subject["hashid"] } == 'Fpbg8CbSbOQ81JSd3HmPFk'
+      insist { subject.get("hashid") } == 'Fpbg8CbSbOQ81JSd3HmPFk'
     end
   end
 
@@ -33,7 +33,7 @@ describe LogStash::Filters::Hashid do
     CONFIG
 
     sample("message" => "testmessage") do
-      insist { subject["hashid"] } == 'qSqS_gZ8GqZGA8d2'
+      insist { subject.get("hashid") } == 'qSqS_gZ8GqZGA8d2'
     end
   end
 
@@ -49,7 +49,7 @@ describe LogStash::Filters::Hashid do
     CONFIG
 
     sample("message" => "testmessage") do
-      insist { subject["hashid"] } == 'sOoRSauukymQT3a8q4C8FZyDncw'
+      insist { subject.get("hashid") } == 'sOoRSauukymQT3a8q4C8FZyDncw'
     end
   end
 
@@ -66,7 +66,7 @@ describe LogStash::Filters::Hashid do
     CONFIG
 
     sample("message" => "testmessage") do
-      insist { subject["hashid"] } == 'arW8XSWIHJ8EYguE'
+      insist { subject.get("hashid") } == 'arW8XSWIHJ8EYguE'
     end
   end
 
@@ -82,7 +82,7 @@ describe LogStash::Filters::Hashid do
     CONFIG
 
     sample("message" => "testmessage") do
-      insist { subject["hashid"] } == 'UZ8NNsx-LsLjV7S6ElKKyMG_Xv274XQE_-nRv-UNgm3'
+      insist { subject.get("hashid") } == 'UZ8NNsx-LsLjV7S6ElKKyMG_Xv274XQE_-nRv-UNgm3'
     end
   end
 
@@ -99,7 +99,7 @@ describe LogStash::Filters::Hashid do
     CONFIG
 
     sample("message" => "testmessage") do
-      insist { subject["hashid"] } == 'm0NantFBrDk6qABW'
+      insist { subject.get("hashid") } == 'm0NantFBrDk6qABW'
     end
   end
 
@@ -115,7 +115,7 @@ describe LogStash::Filters::Hashid do
     CONFIG
 
     sample("message" => "testmessage") do
-      insist { subject["hashid"] } == 'uvdBF5FfTA-ns_Ou6QWTTKsmOCH8T7j6691tr3N7DtZlAeDSvawhWfTAKwwJq9c2'
+      insist { subject.get("hashid") } == 'uvdBF5FfTA-ns_Ou6QWTTKsmOCH8T7j6691tr3N7DtZlAeDSvawhWfTAKwwJq9c2'
     end
   end
 
@@ -132,7 +132,7 @@ describe LogStash::Filters::Hashid do
     CONFIG
 
     sample("message" => "testmessage") do
-      insist { subject["hashid"] } == 'vawhWfTAKwwJq9c2'
+      insist { subject.get("hashid") } == 'vawhWfTAKwwJq9c2'
     end
   end
 
@@ -148,7 +148,7 @@ describe LogStash::Filters::Hashid do
     CONFIG
 
     sample("message" => "testmessage") do
-      insist { subject["hashid"] } == 'ODUuPJaePwJupNWp1exdZJWRrz1aLATtrD0yzOrVBce9hUkhtW266C4djjkp4kqLVU9LtlPh0IermOgJpJx9VV'
+      insist { subject.get("hashid") } == 'ODUuPJaePwJupNWp1exdZJWRrz1aLATtrD0yzOrVBce9hUkhtW266C4djjkp4kqLVU9LtlPh0IermOgJpJx9VV'
     end
   end
 
@@ -165,7 +165,7 @@ describe LogStash::Filters::Hashid do
     CONFIG
 
     sample("message" => "testmessage") do
-      insist { subject["hashid"] } == '4eo4DfU8alIKIoe1'
+      insist { subject.get("hashid") } == '4eo4DfU8alIKIoe1'
     end
   end
 
@@ -184,7 +184,7 @@ describe LogStash::Filters::Hashid do
       CONFIG
 
       sample("@timestamp" => epoch_time, "message" => "testmessage") do
-        insist { subject["hashid"] } == 'KcMSc3COv1IOrOqLmF_6PG3gaZB'
+        insist { subject.get("hashid") } == 'KcMSc3COv1IOrOqLmF_6PG3gaZB'
       end
     end
 
@@ -200,7 +200,7 @@ describe LogStash::Filters::Hashid do
       CONFIG
 
       sample("@timestamp" => epoch_time, "part1" => "test", "part2" => "message") do
-        insist { subject["hashid"] } == 'KcMSc-8mTz750RP7I-pCuae4U6o'
+        insist { subject.get("hashid") } == 'KcMSc-8mTz750RP7I-pCuae4U6o'
       end
     end
 
@@ -216,7 +216,7 @@ describe LogStash::Filters::Hashid do
       CONFIG
 
       sample("@timestamp" => epoch_time, "part2" => "message", "part1" => "test") do
-        insist { subject["hashid"] } == 'KcMSc-8mTz750RP7I-pCuae4U6o'
+        insist { subject.get("hashid") } == 'KcMSc-8mTz750RP7I-pCuae4U6o'
       end
     end
 
@@ -232,7 +232,7 @@ describe LogStash::Filters::Hashid do
       CONFIG
 
       sample("@timestamp" => epoch_time, "message" => "testmessage") do
-        insist { subject["hashid"] } == 'KcMSc6IRDIqJMU6VN1x0TKt2fIo'
+        insist { subject.get("hashid") } == 'KcMSc6IRDIqJMU6VN1x0TKt2fIo'
       end
     end
 
@@ -249,17 +249,17 @@ describe LogStash::Filters::Hashid do
       CONFIG
 
       sample("@timestamp" => epoch_time, "message" => "testmessage") do
-        insist { subject["hashid"] } == 'KcMScCbSbOQ81JSd3HmPFk'
+        insist { subject.get("hashid") } == 'KcMScCbSbOQ81JSd3HmPFk'
       end
     end
 
-    describe '12 byte MD5 with custom timestamp prefix' do
+    describe '12 byte MD5 with custom timestamp field used for prefix' do
       config <<-CONFIG
         filter {
           hashid {
             source => ['message']
             method => 'MD5'
-            timestamp_field => "ts"
+            timestamp_field => 'ts'
             add_timestamp_prefix => true
             hash_bytes_used => 12
           }
@@ -267,7 +267,7 @@ describe LogStash::Filters::Hashid do
       CONFIG
 
       sample("ts" => epoch_time, "message" => "testmessage") do
-        insist { subject["hashid"] } == 'KcMScCbSbOQ81JSd3HmPFk'
+        insist { subject.get("hashid") } == 'KcMScCbSbOQ81JSd3HmPFk'
       end
     end
   end


### PR DESCRIPTION
Updated the gemspec and modified the code to handle the updated event interface. Temporarily removed the ability to specify a custom timestamp field, meaning that @timestamp now always will be used as a base for timestamp prefixed hashids.
