### PR TITLE
Change config key type to `Password`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+## 0.1.4
+  - Key config type changed to `Password` for better protection from leaks in debug logs. [#7](https://github.com/logstash-plugins/logstash-filter-hashid/pull/7)
+
 ## 0.1.3
   - Asciidoc fixes

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -43,7 +43,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-add_timestamp_prefix>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-hash_bytes_used>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-key>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-key>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-method>> |<<string,string>>, one of `["SHA1", "SHA256", "SHA384", "SHA512", "MD5"]`|No
 | <<plugins-{type}s-{plugin}-source>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
@@ -74,7 +74,7 @@ If not specified, the full hash will be used
 [id="plugins-{type}s-{plugin}-key"]
 ===== `key` 
 
-  * Value type is <<string,string>>
+  * Value type is <<password,password>>
   * Default value is `"hashid"`
 
 Encryption key to be used when generating cryptographic hashes

--- a/lib/logstash/filters/hashid.rb
+++ b/lib/logstash/filters/hashid.rb
@@ -26,7 +26,7 @@ class LogStash::Filters::Hashid < LogStash::Filters::Base
   config :target, :validate => :string, :default => 'hashid'
 
   # Encryption key to be used when generating cryptographic hashes
-  config :key, :validate => :string, :default => 'hashid'
+  config :key, :validate => :password, :default => 'hashid'
 
   # Hash function to use
   config :method, :validate => ['SHA1', 'SHA256', 'SHA384', 'SHA512', 'MD5'], :default => 'MD5'
@@ -48,7 +48,7 @@ class LogStash::Filters::Hashid < LogStash::Filters::Base
   end
 
   def filter(event)
-    hmac = OpenSSL::HMAC.new(@key, @digest.new)
+    hmac = OpenSSL::HMAC.new(@key.value, @digest.new)
 
     @source.sort.each do |k|
       hmac.update("|#{k}|#{event.get(k)}") 

--- a/logstash-filter-hashid.gemspec
+++ b/logstash-filter-hashid.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-hashid'
-  s.version         = '0.1.3'
+  s.version         = '0.1.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This filter lets you create base64 encoded event IDs based on the event contents and timestamp using a number of hash functions."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/hashid_spec.rb
+++ b/spec/filters/hashid_spec.rb
@@ -5,6 +5,8 @@ require "logstash/filters/hashid"
 
 describe LogStash::Filters::Hashid do
 
+  let(:plugin) { described_class.new(config) }
+
   describe 'Full MD5, no timestamp prefix' do
     config <<-CONFIG
       filter {
@@ -256,4 +258,14 @@ describe LogStash::Filters::Hashid do
 
   end
 
+  describe "debugging key" do
+    let(:config) {{ "key" => "$ecre&-key" }}
+
+    it "should not show origin value" do
+      expect(plugin.logger).to receive(:debug).with('<password>')
+
+      plugin.register
+      plugin.logger.send(:debug, plugin.key.to_s)
+    end
+  end
 end


### PR DESCRIPTION
### Description
This PR ensures to protect the `:key` from leaks in the debug logs.

- Closes #6 

### Test
```
# config
input {
  stdin {}
}
filter {
    hashid {
      key => "super-secret"
    }
}
output {
    stdout {
        codec => rubydebug
    }
}
```


```
# Log before change
[2022-12-05T12:32:21,786][INFO ][logstash.filters.hashid  ] Using version 0.1.x filter plugin 'hashid'. This plugin isn't well supported by the community and likely has no maintainer.
[2022-12-05T12:32:21,788][DEBUG][logstash.filters.hashid  ] config LogStash::Filters::Hashid/@key = "super-secret"

# Log after change
[2022-12-05T12:52:41,978][INFO ][logstash.filters.hashid  ] Using version 0.1.x filter plugin 'hashid'. This plugin isn't well supported by the community and likely has no maintainer.
[2022-12-05T12:52:41,980][DEBUG][logstash.filters.hashid  ] config LogStash::Filters::Hashid/@key = <password>
[2022-12-05T12:52:41,980][DEBUG][logstash.filters.hashid  ] config LogStash::Filters::Hashid/@id = "bd8da67e997422ead07ee219c8ba8ed3805029d2d87ab26e28a6faf7302e47aa"
```

```
# output
{
         "event" => {
        "original" => "hi"
    },
       "message" => "hi",
    "@timestamp" => 2022-12-05T07:53:13.086391Z,
      "@version" => "1",
        "hashid" => "NsqYPOvHcjIgZBfCd1dsR5vl8_3",
          "host" => {
        "hostname" => "Mashhurs-MacBook-Pro.local"
    }
}
```